### PR TITLE
Use secrets.GITHUB_TOKEN to talk to Github API

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ runs:
       run: |
         set -x
         mkdir ${{github.action_path}}/bin
-        curl -sL $(curl -s https://api.github.com/repos/koyeb/koyeb-cli/releases/latest \
+        curl -sL -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' $(curl -s -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/koyeb/koyeb-cli/releases/latest \
           | grep 'http.*koyeb-cli_.*_linux_amd64' \
           | awk '{print $2}' \
           | sed 's|[\"\,]*||g') | tar xvz -C ${{github.action_path}}/bin/


### PR DESCRIPTION
This makes the action use the repo's token to talk to Github API. Thus, rate limiting is applied to the customer's account and not to the CI machine's IP